### PR TITLE
chore: small cleanup

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -8,7 +8,8 @@ on:
     inputs:
       COMMITS_HISTORY:
         description: 'Number of commits to consider, starting with most recent (e.g. 1 = only look at most recent).'
-        default: 16
+        # 250 appears to be the limit of `gh api --paginate $COMMITS_URL`
+        default: 250
         required: false
         type: number
 
@@ -30,11 +31,7 @@ jobs:
     - name: Fetch PR Details
       shell: bash
       run: |
-        if [[ $GITHUB_TOKEN ]]; then
-          json=$( curl --header "Authorization: Bearer $GITHUB_TOKEN" --fail --retry 3 --silent "$COMMITS_URL" )
-        else
-          json=$( curl --fail --retry 3 --silent "$COMMITS_URL" )
-        fi
+        json=$( gh api --paginate $COMMITS_URL )
         echo 'commits<<EOF' >> $GITHUB_ENV
         echo "COMMITS_HISTORY = ${{ inputs.COMMITS_HISTORY }}"
         echo $json | jq --raw-output '.[] | [.sha, (.commit.message | split("\n") | first)] | join(" ")'
@@ -59,10 +56,10 @@ jobs:
           commit_hash_short=${commit:0:7}
         
           if [[ ! $commit_title =~ $SEMANTIC_PATTERN ]]; then
-            echo ::error::Commit title $commit_hash_short not semantic: "$commit_title"
+            echo ::error::$commit_hash_short not semantic: "$commit_title"
             exit_code=1
           else
-            echo Commit title $commit_hash_short OK: "$commit_title"
+            echo $commit_hash_short OK: "$commit_title"
           fi
         done <<< $commits
         

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To test:
 ./test_semantic_pattern.sh
 ```
 
-To use this workflow in your repo, create file `.github/workflows/semantic.yml:
+To use this workflow in your repo, create file `.github/workflows/semantic.yml`:
 ```yaml
 ---
 name: "Semantic PR and Commit Messages"
@@ -21,6 +21,7 @@ on:
 jobs:
   semantic:
     uses: influxdata/validate-semantic-github-messages/.github/workflows/semantic.yml@main
+    # optional; 250 is default and max
     with:
       COMMITS_HISTORY: 1
 ```

--- a/semantic_script.sh
+++ b/semantic_script.sh
@@ -13,10 +13,10 @@ while read -r commit; do
   commit_hash_short=${commit:0:7}
 
   if [[ ! $commit_title =~ $SEMANTIC_PATTERN ]]; then
-    echo ::error::Commit title $commit_hash_short not semantic: "$commit_title"
+    echo ::error::$commit_hash_short not semantic: "$commit_title"
     exit_code=1
   else
-    echo Commit title $commit_hash_short OK: "$commit_title"
+    echo $commit_hash_short OK: "$commit_title"
   fi
 done <<< $commits
 

--- a/workflow_template.yml
+++ b/workflow_template.yml
@@ -8,7 +8,8 @@ on:
     inputs:
       COMMITS_HISTORY:
         description: 'Number of commits to consider, starting with most recent (e.g. 1 = only look at most recent).'
-        default: 16
+        # 250 appears to be the limit of `gh api --paginate $COMMITS_URL`
+        default: 250
         required: false
         type: number
 
@@ -30,11 +31,7 @@ jobs:
     - name: Fetch PR Details
       shell: bash
       run: |
-        if [[ $GITHUB_TOKEN ]]; then
-          json=$( curl --header "Authorization: Bearer $GITHUB_TOKEN" --fail --retry 3 --silent "$COMMITS_URL" )
-        else
-          json=$( curl --fail --retry 3 --silent "$COMMITS_URL" )
-        fi
+        json=$( gh api --paginate $COMMITS_URL )
         echo 'commits<<EOF' >> $GITHUB_ENV
         echo "COMMITS_HISTORY = ${{ inputs.COMMITS_HISTORY }}"
         echo $json | jq --raw-output '.[] | [.sha, (.commit.message | split("\n") | first)] | join(" ")'


### PR DESCRIPTION
- default and max commit history is now 250
- small text cleanups
- use `gh` instead of `curl`