### PR TITLE
refactor: reference doc URL in failure message

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -63,4 +63,12 @@ jobs:
           fi
         done <<< $commits
         
+        if [ $exit_code -ne 0 ]; then
+          echo
+          echo "This repository uses semantic commit messages"
+          echo "check out https://www.conventionalcommits.org/ for more information"
+          echo "and rewrite any rejected commit messages to pass CI - thanks!"
+          echo
+        fi
+        
         exit $exit_code

--- a/semantic_script.sh
+++ b/semantic_script.sh
@@ -20,4 +20,12 @@ while read -r commit; do
   fi
 done <<< $commits
 
+if [ $exit_code -ne 0 ]; then
+  echo
+  echo "This repository uses semantic commit messages"
+  echo "check out https://www.conventionalcommits.org/ for more information"
+  echo "and rewrite any rejected commit messages to pass CI - thanks!"
+  echo
+fi
+
 exit $exit_code


### PR DESCRIPTION
External contributors might not be familiar with semantic commits and if their PRs fail it requires a manual "check out this URL" response from maintainers, potentially hours/days later.

This failure message should help point the contributor in the right direction to pass CI immediately so they can resolve the failure themselves and be happy knowing the machines won 👍 

---

* refactor: reference doc URL in failure message (2a5c55b)

      This commit prints a message when the check fails, referencing the 
      conventional commits URL to help contributors understand what they need to do
      to resolve the failure.