### PR TITLE
chore: add "security" commit type

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -23,7 +23,7 @@ env:
   COMMITS_URL: ${{ github.event.pull_request.commits_url }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SEMANTIC_PATTERN: |-
-    ^(Merge .*branch '.+'( of .+)? into|Revert ".+"|(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^)]+\))?: +[^ ])
+    ^(Merge .*branch '.+'( of .+)? into|Revert ".+"|(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|security)(\([^)]+\))?: +[^ ])
 
 jobs:
   main:

--- a/semantic_pattern.txt
+++ b/semantic_pattern.txt
@@ -1,1 +1,1 @@
-^(Merge .*branch '.+'( of .+)? into|Revert ".+"|(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^)]+\))?: +[^ ])
+^(Merge .*branch '.+'( of .+)? into|Revert ".+"|(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|security)(\([^)]+\))?: +[^ ])

--- a/test_semantic_pattern.sh
+++ b/test_semantic_pattern.sh
@@ -11,6 +11,8 @@ echo checking PR and commit titles that should be OK
 expect_ok=$( cat << EOF
 chore: foo
 chore(hello): foo
+security: bar
+security(hello): bar
 Revert "fix: certain this fix is correct!"
 Merge remote-tracking branch 'origin/main' into alamb/update_df_101
 Merge branch 'main' into foo
@@ -37,6 +39,10 @@ chore:foo
 Chore: foo
 Revert my thing
 Merge this is not a legit merge
+security
+security:
+security\(:
+Security: bar
 EOF
 )
 


### PR DESCRIPTION
This adds `security` to the list of accepted commit types. This is part of a plan to have a `Security` heading in `CHANGELOG.md` entries. 