### PR TITLE
chore: bump version of checkout action

### DIFF
--- a/workflow_template.yml
+++ b/workflow_template.yml
@@ -29,7 +29,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 


### PR DESCRIPTION
`actions/checkout@v2` uses an old version of node, so I've been bumping this where appropriate to v4, latest. This will eliminate a notice appended to every action using this validator suggesting that it should be updated.

See: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/