### PR TITLE
chore: Bump checkout action in GitHub workflow actions to latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -29,7 +29,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 


### PR DESCRIPTION
This PR is a follow up of #22. It updates `checkout` action to latest version for `ci` and `semantic` workflow in order to avoid deprecation warnings as seen for example [here](https://github.com/influxdata/telegraf/actions/runs/7200496994).