### PR TITLE
fix: Allow new Github merge pull request pattern

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -23,7 +23,7 @@ env:
   COMMITS_URL: ${{ github.event.pull_request.commits_url }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SEMANTIC_PATTERN: |-
-    ^(Merge .*branch '.+'( of .+)? into|Revert ".+"|(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^)]+\))?(\!)?: +[^ ])
+    ^(Merge .*branch '.+'( of .+)? into|Merge pull request #[0-9]+ from|Revert ".+"|(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^)]+\))?(\!)?: +[^ ])
 
 jobs:
   main:

--- a/semantic_pattern.txt
+++ b/semantic_pattern.txt
@@ -1,1 +1,1 @@
-^(Merge .*branch '.+'( of .+)? into|Revert ".+"|(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^)]+\))?(\!)?: +[^ ])
+^(Merge .*branch '.+'( of .+)? into|Merge pull request #[0-9]+ from|Revert ".+"|(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^)]+\))?(\!)?: +[^ ])

--- a/test_semantic_pattern.sh
+++ b/test_semantic_pattern.sh
@@ -15,6 +15,7 @@ chore: foo
 chore(hello): foo
 Revert "fix: certain this fix is correct!"
 Merge remote-tracking branch 'origin/main' into alamb/update_df_101
+Merge pull request #9914 from influxdata/alamb/ingester_pruning_tweak
 Merge branch 'main' into foo
 Merge branch 'main' of xyzpdq into foo
 EOF


### PR DESCRIPTION
My branch is sad, because it looks like merging pull requests produces a message we don't handle yet. See [this action](https://github.com/influxdata/influxdb_iox/actions/runs/7657050257/job/20866810699?pr=9902)

---

* fix: Allow new Github merge pull request pattern (661ca5f)


* chore: Generate, generate (ffa83db)